### PR TITLE
Fix: BindableObject is replaced by the ObservableObject

### DIFF
--- a/ListFromJson/ContentView.swift
+++ b/ListFromJson/ContentView.swift
@@ -9,10 +9,10 @@
 import SwiftUI
 
 struct ContentView : View {
-    @State var networkingManager = NetworkingManager()
+    @ObservedObject var networkingManager = NetworkingManager()
     
     var body: some View {
-        List(networkingManager.pokemonList.results.identified(by: \.url)) { pokemon in
+        List(networkingManager.pokemonList.results, id: \.url) { pokemon in
             Text(pokemon.name.capitalized)
         }
     }

--- a/ListFromJson/NetworkingManager.swift
+++ b/ListFromJson/NetworkingManager.swift
@@ -10,14 +10,8 @@ import Foundation
 import SwiftUI
 import Combine
 
-class NetworkingManager : BindableObject {
-    var didChange = PassthroughSubject<NetworkingManager, Never>()
-    
-    var pokemonList = PokemonAPIList(results: []) {
-        didSet {
-            didChange.send(self)
-        }
-    }
+class NetworkingManager: ObservableObject {
+    @Published var pokemonList = PokemonAPIList(results: [])
     
     init() {
         guard let url = URL(string: "https://pokeapi.co/api/v2/pokemon?limit=151") else { return }


### PR DESCRIPTION
In Swift Beta 5 BindableObject was deprecated in favour of ObservableObject.

I've updated the pattern to now use ObservableObject & work with Swift 5.

Further info: https://stackoverflow.com/a/57087833/9328054

Closes https://github.com/brentschooley/swiftui-json-list/issues/1